### PR TITLE
Fix code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -28,11 +28,9 @@ namespace UnsecureApp.Controllers
         {
             using (SqlConnection connection = new SqlConnection(connectionString))
             {
-                SqlCommand sqlCommand = new SqlCommand()
-                {
-                    CommandText = "SELECT ProductId FROM Products WHERE ProductName = '" + productName + "'",
-                    CommandType = CommandType.Text,
-                };
+                SqlCommand sqlCommand = new SqlCommand("SELECT ProductId FROM Products WHERE ProductName = @productName", connection);
+                sqlCommand.CommandType = CommandType.Text;
+                sqlCommand.Parameters.AddWithValue("@productName", productName);
 
                 SqlDataReader reader = sqlCommand.ExecuteReader();
                 return reader.GetInt32(0); 


### PR DESCRIPTION
Fixes [https://github.com/geovanams/reactorGHAS/security/code-scanning/2](https://github.com/geovanams/reactorGHAS/security/code-scanning/2)

To fix the SQL injection vulnerability, we should use parameterized queries instead of string concatenation. This approach ensures that user input is treated as a parameter and not as part of the SQL command, thus preventing SQL injection attacks.

**Steps to fix the problem:**
1. Modify the SQL query to use a parameter placeholder (`@productName`) instead of concatenating the `productName` directly into the query string.
2. Add the `productName` as a parameter to the `SqlCommand` object.
3. Ensure the `SqlCommand` object is associated with the `SqlConnection` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
