### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -10,7 +10,22 @@ namespace UnsecureApp.Controllers
 
         public string ReadFile(string userInput)
         {
-            using (FileStream fs = File.Open(userInput, FileMode.Open))
+            // Validate user input
+            if (userInput.Contains("..") || userInput.Contains("/") || userInput.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid path");
+            }
+
+            string safeDirectory = "/safe/directory"; // Define a safe directory
+            string filePath = Path.GetFullPath(Path.Combine(safeDirectory, userInput));
+
+            // Ensure the path stays within the safe directory
+            if (!filePath.StartsWith(safeDirectory + Path.DirectorySeparatorChar))
+            {
+                throw new ArgumentException("Invalid path");
+            }
+
+            using (FileStream fs = File.Open(filePath, FileMode.Open))
             {
                 byte[] b = new byte[1024];
                 UTF8Encoding temp = new UTF8Encoding(true);


### PR DESCRIPTION
Fixes [https://github.com/geovanams/reactorGHAS/security/code-scanning/1](https://github.com/geovanams/reactorGHAS/security/code-scanning/1)

To fix the problem, we need to validate the `userInput` before using it to construct a file path. The best way to do this is to ensure that the `userInput` does not contain any path separators or parent directory references. This can be achieved by checking for the presence of "..", "/", or "\\" in the `userInput` and rejecting the input if any are found.

Additionally, we can ensure that the resolved path is contained within a specific directory to further mitigate the risk of path traversal attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
